### PR TITLE
Backend support for creating snapshots

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -112,6 +112,7 @@ var (
 	VolumeURL       = "/" + OrchestratorName + "/v" + OrchestratorAPIVersion + "/volume"
 	TransactionURL  = "/" + OrchestratorName + "/v" + OrchestratorAPIVersion + "/txn"
 	StorageClassURL = "/" + OrchestratorName + "/v" + OrchestratorAPIVersion + "/storageclass"
+	SnapshotURL     = "/" + OrchestratorName + "/v" + OrchestratorAPIVersion + "/snapshot"
 	StoreURL        = "/" + OrchestratorName + "/store"
 
 	UsingPassthroughStore bool

--- a/core/orchestrator_core.go
+++ b/core/orchestrator_core.go
@@ -1365,6 +1365,49 @@ func (o *TridentOrchestrator) DetachVolume(volumeName, mountpoint string) error 
 	return nil
 }
 
+// CreateVolumeSnapshot creates a snapshot of the given volume
+func (o *TridentOrchestrator) CreateVolumeSnapshot(
+	snapshotName string, volumeConfig *storage.VolumeConfig,
+) (*storage.SnapshotExternal, error) {
+
+	if o.bootstrapError != nil {
+		return nil, o.bootstrapError
+	}
+
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	// Get the source volume
+	sourceVolume, ok := o.volumes[volumeConfig.Name]
+	if !ok {
+		return nil, notFoundError(fmt.Sprintf("source volume %s not found", volumeConfig.Name))
+	}
+	volumeConfig.Version = config.OrchestratorAPIVersion
+
+	// Get the corresponding backend
+	backend, found := o.backends[sourceVolume.Backend]
+	if !found {
+		// Should never get here but just to be safe
+		return nil, notFoundError(fmt.Sprintf("backend %s for the source volume not found: %s",
+			sourceVolume.Backend, volumeConfig.Name))
+	}
+
+	// Create the snapshot
+	snapshot, err := backend.CreateVolumeSnapshot(snapshotName, volumeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create snapshot for volume %s on backend %s: %v", volumeConfig.Name,
+			backend.Name, err)
+	}
+
+	// Save references to new snapshot in the persistent store
+	err = o.storeClient.AddSnapshot(volumeConfig.Name, snapshot)
+	if err != nil {
+		return nil, err
+	}
+
+	return snapshot.ConstructExternal(), nil
+}
+
 func (o *TridentOrchestrator) ListVolumeSnapshots(volumeName string) ([]*storage.SnapshotExternal, error) {
 	if o.bootstrapError != nil {
 		return nil, o.bootstrapError

--- a/core/orchestrator_core_test.go
+++ b/core/orchestrator_core_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -2019,4 +2020,186 @@ func TestOrchestratorNotReady(t *testing.T) {
 	if !IsNotReadyError(err) {
 		t.Errorf("Expected DeleteStorageClass to return an error.")
 	}
+}
+
+func TestSnapshotVolumes(t *testing.T) {
+	mockPools := tu.GetFakePools()
+	orchestrator := getOrchestrator()
+
+	errored := false
+	for _, c := range []struct {
+		name      string
+		protocol  config.Protocol
+		poolNames []string
+	}{
+		{
+			name:      "fast-a",
+			protocol:  config.File,
+			poolNames: []string{tu.FastSmall, tu.FastThinOnly},
+		},
+		{
+			name:      "fast-b",
+			protocol:  config.File,
+			poolNames: []string{tu.FastThinOnly, tu.FastUniqueAttr},
+		},
+		{
+			name:      "slow-file",
+			protocol:  config.File,
+			poolNames: []string{tu.SlowNoSnapshots, tu.SlowSnapshots},
+		},
+		{
+			name:      "slow-block",
+			protocol:  config.Block,
+			poolNames: []string{tu.SlowNoSnapshots, tu.SlowSnapshots, tu.MediumOverlap},
+		},
+	} {
+		pools := make(map[string]*fake.StoragePool, len(c.poolNames))
+		for _, poolName := range c.poolNames {
+			pools[poolName] = mockPools[poolName]
+		}
+		cfg, err := fakedriver.NewFakeStorageDriverConfigJSON(c.name, c.protocol,
+			pools)
+		if err != nil {
+			t.Fatalf("Unable to generate cfg JSON for %s:  %v", c.name, err)
+		}
+		_, err = orchestrator.AddBackend(cfg)
+		if err != nil {
+			t.Errorf("Unable to add backend %s:  %v", c.name, err)
+			errored = true
+		}
+		orchestrator.mutex.Lock()
+		backend, ok := orchestrator.backends[c.name]
+		if !ok {
+			t.Fatalf("Backend %s not stored in orchestrator", c.name)
+		}
+		persistentBackend, err := orchestrator.storeClient.GetBackend(
+			c.name)
+		if err != nil {
+			t.Fatalf("Unable to get backend %s from persistent store:  %v",
+				c.name, err)
+		} else if !reflect.DeepEqual(backend.ConstructPersistent(),
+			persistentBackend) {
+			t.Error("Wrong data stored for backend ", c.name)
+		}
+		orchestrator.mutex.Unlock()
+	}
+	if errored {
+		t.Fatal("Failed to add all backends; aborting remaining tests.")
+	}
+
+	// Add storage classes
+	storageClasses := []storageClassTest{
+		{
+			config: &storageclass.Config{
+				Name: "slow",
+				Attributes: map[string]sa.Request{
+					sa.IOPS:             sa.NewIntRequest(40),
+					sa.Snapshots:        sa.NewBoolRequest(true),
+					sa.ProvisioningType: sa.NewStringRequest("thin"),
+				},
+			},
+			expected: []*tu.PoolMatch{
+				{Backend: "slow-file", Pool: tu.SlowSnapshots},
+				{Backend: "slow-block", Pool: tu.SlowSnapshots},
+			},
+		},
+		{
+			config: &storageclass.Config{
+				Name: "fast",
+				Attributes: map[string]sa.Request{
+					sa.IOPS:             sa.NewIntRequest(2000),
+					sa.Snapshots:        sa.NewBoolRequest(true),
+					sa.ProvisioningType: sa.NewStringRequest("thin"),
+				},
+			},
+			expected: []*tu.PoolMatch{
+				{Backend: "fast-a", Pool: tu.FastSmall},
+				{Backend: "fast-a", Pool: tu.FastThinOnly},
+				{Backend: "fast-b", Pool: tu.FastThinOnly},
+				{Backend: "fast-b", Pool: tu.FastUniqueAttr},
+			},
+		},
+	}
+	for _, s := range storageClasses {
+		_, err := orchestrator.AddStorageClass(s.config)
+		if err != nil {
+			t.Errorf("Unable to add storage class %s:  %v", s.config.Name, err)
+			continue
+		}
+		validateStorageClass(t, orchestrator, s.config.Name, s.expected)
+	}
+
+	for _, s := range []struct {
+		name            string
+		config          *storage.VolumeConfig
+		expectedSuccess bool
+		expectedMatches []*tu.PoolMatch
+	}{
+		{
+			name:            "file",
+			config:          generateVolumeConfig("file", 1, "fast", config.File),
+			expectedSuccess: true,
+			expectedMatches: []*tu.PoolMatch{
+				{Backend: "fast-a", Pool: tu.FastSmall},
+				{Backend: "fast-a", Pool: tu.FastThinOnly},
+				{Backend: "fast-b", Pool: tu.FastThinOnly},
+				{Backend: "fast-b", Pool: tu.FastUniqueAttr},
+			},
+		},
+		{
+			name:            "block",
+			config:          generateVolumeConfig("block", 1, "slow", config.Block),
+			expectedSuccess: true,
+			expectedMatches: []*tu.PoolMatch{
+				{Backend: "slow-block", Pool: tu.SlowSnapshots},
+				{Backend: "slow-block", Pool: tu.SlowSnapshots},
+			},
+		},
+	} {
+		// Create the source volume
+		_, err := orchestrator.AddVolume(s.config)
+		if err != nil {
+			t.Errorf("%s: could not add volume: %v", s.name, err)
+			continue
+		}
+
+		orchestrator.mutex.Lock()
+		_, found := orchestrator.volumes[s.config.Name]
+		if s.expectedSuccess && !found {
+			t.Errorf("%s: did not get volume where expected.", s.name)
+			continue
+		}
+		orchestrator.mutex.Unlock()
+
+		// Now take a snapshot and ensure everything looks fine
+		snapshotName := s.config.Name + "_snapshot" + time.Now().UTC().Format("20060102T150405Z")
+		snapshotResult, err := orchestrator.CreateVolumeSnapshot(snapshotName, s.config)
+		if err != nil {
+			t.Fatalf("%s: got unexpected error: %v", s.name, err)
+		}
+
+		orchestrator.mutex.Lock()
+		// Snapshot should be registered in the store
+		externalSnapshot, err := orchestrator.storeClient.GetSnapshot(s.config.Name, snapshotName)
+		if err != nil {
+			t.Errorf("%s: unable to communicate with backing store:  %v", snapshotName, err)
+		}
+		if !reflect.DeepEqual(externalSnapshot, snapshotResult) {
+			t.Errorf("%s: external snapshot %s stored in backend does not match"+
+				" created snapshot.", snapshotName, externalSnapshot.Snapshot.Name)
+			externalSnapshotJSON, err := json.Marshal(externalSnapshot)
+			if err != nil {
+				t.Fatal("Unable to remarshal JSON:  ", err)
+			}
+			origSnapshotJSON, err := json.Marshal(snapshotResult)
+			if err != nil {
+				t.Fatal("Unable to remarshal JSON:  ", err)
+			}
+			t.Logf("\tExpected: %s\n\tGot: %s\n", string(externalSnapshotJSON), string(origSnapshotJSON))
+		}
+
+		orchestrator.mutex.Unlock()
+	}
+
+	cleanup(t, orchestrator)
 }

--- a/core/orchestrator_core_test.go
+++ b/core/orchestrator_core_test.go
@@ -2172,7 +2172,7 @@ func TestSnapshotVolumes(t *testing.T) {
 		orchestrator.mutex.Unlock()
 
 		// Now take a snapshot and ensure everything looks fine
-		snapshotName := s.config.Name + "_snapshot" + time.Now().UTC().Format("20060102T150405Z")
+		snapshotName := s.config.Name + "_snapshot" + time.Now().UTC().Format(time.RFC3339)
 		snapshotResult, err := orchestrator.CreateVolumeSnapshot(snapshotName, s.config)
 		if err != nil {
 			t.Fatalf("%s: got unexpected error: %v", s.name, err)
@@ -2182,18 +2182,18 @@ func TestSnapshotVolumes(t *testing.T) {
 		// Snapshot should be registered in the store
 		externalSnapshot, err := orchestrator.storeClient.GetSnapshot(s.config.Name, snapshotName)
 		if err != nil {
-			t.Errorf("%s: unable to communicate with backing store:  %v", snapshotName, err)
+			t.Errorf("%s: unable to communicate with backing store: %v", snapshotName, err)
 		}
 		if !reflect.DeepEqual(externalSnapshot, snapshotResult) {
 			t.Errorf("%s: external snapshot %s stored in backend does not match"+
-				" created snapshot.", snapshotName, externalSnapshot.Snapshot.Name)
+				" created snapshot.", snapshotName, externalSnapshot.Name)
 			externalSnapshotJSON, err := json.Marshal(externalSnapshot)
 			if err != nil {
-				t.Fatal("Unable to remarshal JSON:  ", err)
+				t.Fatal("Unable to remarshal JSON: ", err)
 			}
 			origSnapshotJSON, err := json.Marshal(snapshotResult)
 			if err != nil {
-				t.Fatal("Unable to remarshal JSON:  ", err)
+				t.Fatal("Unable to remarshal JSON: ", err)
 			}
 			t.Logf("\tExpected: %s\n\tGot: %s\n", string(externalSnapshotJSON), string(origSnapshotJSON))
 		}

--- a/persistent_store/etcdv2.go
+++ b/persistent_store/etcdv2.go
@@ -570,11 +570,7 @@ func (p *EtcdClientV2) AddSnapshot(volName string, snapshot *storage.Snapshot) e
 	if err != nil {
 		return err
 	}
-	err = p.Create(config.SnapshotURL+"/"+volName+"/"+snapshot.Name, string(snapJSON))
-	if err != nil {
-		return err
-	}
-	return nil
+	return p.Create(config.SnapshotURL+"/"+volName+"/"+snapshot.Name, string(snapJSON))
 }
 
 // GetSnapshot fetches a snapshot's state from the persistent store
@@ -584,8 +580,7 @@ func (p *EtcdClientV2) GetSnapshot(volName, snapshotName string) (*storage.Snaps
 		return nil, err
 	}
 	snapExternal := &storage.SnapshotExternal{}
-	err = json.Unmarshal([]byte(snapJSON), snapExternal)
-	if err != nil {
+	if err = json.Unmarshal([]byte(snapJSON), snapExternal); err != nil {
 		return nil, err
 	}
 	return snapExternal, nil

--- a/persistent_store/etcdv2.go
+++ b/persistent_store/etcdv2.go
@@ -562,3 +562,31 @@ func (p *EtcdClientV2) DeleteStorageClass(sc *storageclass.StorageClass) error {
 	}
 	return nil
 }
+
+// AddSnapshot adds a snapshot's state to the persistent store
+func (p *EtcdClientV2) AddSnapshot(volName string, snapshot *storage.Snapshot) error {
+	snapExternal := snapshot.ConstructExternal()
+	snapJSON, err := json.Marshal(snapExternal)
+	if err != nil {
+		return err
+	}
+	err = p.Create(config.SnapshotURL+"/"+volName+"/"+snapshot.Name, string(snapJSON))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetSnapshot fetches a snapshot's state from the persistent store
+func (p *EtcdClientV2) GetSnapshot(volName, snapshotName string) (*storage.SnapshotExternal, error) {
+	snapJSON, err := p.Read(config.SnapshotURL + "/" + volName + "/" + snapshotName)
+	if err != nil {
+		return nil, err
+	}
+	snapExternal := &storage.SnapshotExternal{}
+	err = json.Unmarshal([]byte(snapJSON), snapExternal)
+	if err != nil {
+		return nil, err
+	}
+	return snapExternal, nil
+}

--- a/persistent_store/etcdv3.go
+++ b/persistent_store/etcdv3.go
@@ -789,11 +789,7 @@ func (p *EtcdClientV3) AddSnapshot(volName string, snapshot *storage.Snapshot) e
 	if err != nil {
 		return err
 	}
-	err = p.Create(config.SnapshotURL+"/"+volName+"/"+snapshot.Name, string(snapJSON))
-	if err != nil {
-		return err
-	}
-	return nil
+	return p.Create(config.SnapshotURL+"/"+volName+"/"+snapshot.Name, string(snapJSON))
 }
 
 // GetSnapshot fetches a snapshot's state from the persistent store
@@ -803,8 +799,7 @@ func (p *EtcdClientV3) GetSnapshot(volName, snapshotName string) (*storage.Snaps
 		return nil, err
 	}
 	snapExternal := &storage.SnapshotExternal{}
-	err = json.Unmarshal([]byte(snapJSON), snapExternal)
-	if err != nil {
+	if err = json.Unmarshal([]byte(snapJSON), snapExternal); err != nil {
 		return nil, err
 	}
 	return snapExternal, nil

--- a/persistent_store/etcdv3.go
+++ b/persistent_store/etcdv3.go
@@ -781,3 +781,31 @@ func (p *EtcdClientV3) DeleteStorageClass(sc *storageclass.StorageClass) error {
 	}
 	return nil
 }
+
+// AddSnapshot adds a snapshot's state to the persistent store
+func (p *EtcdClientV3) AddSnapshot(volName string, snapshot *storage.Snapshot) error {
+	snapExternal := snapshot.ConstructExternal()
+	snapJSON, err := json.Marshal(snapExternal)
+	if err != nil {
+		return err
+	}
+	err = p.Create(config.SnapshotURL+"/"+volName+"/"+snapshot.Name, string(snapJSON))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetSnapshot fetches a snapshot's state from the persistent store
+func (p *EtcdClientV3) GetSnapshot(volName, snapshotName string) (*storage.SnapshotExternal, error) {
+	snapJSON, err := p.Read(config.SnapshotURL + "/" + volName + "/" + snapshotName)
+	if err != nil {
+		return nil, err
+	}
+	snapExternal := &storage.SnapshotExternal{}
+	err = json.Unmarshal([]byte(snapJSON), snapExternal)
+	if err != nil {
+		return nil, err
+	}
+	return snapExternal, nil
+}

--- a/persistent_store/in_memory.go
+++ b/persistent_store/in_memory.go
@@ -284,14 +284,10 @@ func (c *InMemoryClient) GetSnapshot(volName, snapshotName string) (*storage.Sna
 	if !ok {
 		return nil, NewPersistentStoreError(KeyNotFoundErr, volName)
 	}
-	var ret *storage.SnapshotExternal
 	for _, snapExternal := range snapshots {
 		if snapExternal.Name == snapshotName {
-			ret = snapExternal
+			return snapExternal, nil
 		}
 	}
-	if ret == nil {
-		return nil, NewPersistentStoreError(KeyNotFoundErr, snapshotName)
-	}
-	return ret, nil
+	return nil, NewPersistentStoreError(KeyNotFoundErr, snapshotName)
 }

--- a/persistent_store/passthrough.go
+++ b/persistent_store/passthrough.go
@@ -391,3 +391,11 @@ func (c *PassthroughClient) GetStorageClasses() ([]*sc.Persistent, error) {
 func (c *PassthroughClient) DeleteStorageClass(sc *sc.StorageClass) error {
 	return nil
 }
+
+func (c *PassthroughClient) AddSnapshot(volName string, snapshot *storage.Snapshot) error {
+	return nil
+}
+
+func (c *PassthroughClient) GetSnapshot(volName, snapshotName string) (*storage.SnapshotExternal, error) {
+	return nil, nil
+}

--- a/persistent_store/types.go
+++ b/persistent_store/types.go
@@ -61,6 +61,9 @@ type Client interface {
 	GetStorageClass(scName string) (*storageclass.Persistent, error)
 	GetStorageClasses() ([]*storageclass.Persistent, error)
 	DeleteStorageClass(sc *storageclass.StorageClass) error
+
+	AddSnapshot(volName string, snapshot *storage.Snapshot) error
+	GetSnapshot(volName, snapshotName string) (*storage.SnapshotExternal, error)
 }
 
 type EtcdClient interface {

--- a/storage/backend.go
+++ b/storage/backend.go
@@ -339,11 +339,7 @@ func (b *Backend) CreateVolumeSnapshot(snapshotName string, volConfig *VolumeCon
 	}
 
 	// Create snapshot
-	snapshot, err := b.Driver.CreateSnapshot(snapshotName, volConfig)
-	if err != nil {
-		return nil, err
-	}
-	return snapshot, nil
+	return b.Driver.CreateSnapshot(snapshotName, volConfig)
 }
 
 const (

--- a/storage_drivers/aws/aws_cvs.go
+++ b/storage_drivers/aws/aws_cvs.go
@@ -930,7 +930,7 @@ func (d *NFSStorageDriver) CreateSnapshot(snapshotName string, volConfig *storag
 
 	sourceSnapshot, err := d.API.CreateSnapshot(snapshotCreateRequest)
 	if err != nil {
-		return nil, fmt.Errorf("could not create source snapshot: %v", err)
+		return nil, fmt.Errorf("could not create snapshot: %v", err)
 	}
 
 	// Wait for snapshot creation to complete

--- a/storage_drivers/aws/aws_cvs.go
+++ b/storage_drivers/aws/aws_cvs.go
@@ -878,6 +878,73 @@ func (d *NFSStorageDriver) Publish(name string, publishInfo *utils.VolumePublish
 	return nil
 }
 
+// CreateSnapshot creates a snapshot for the given volume
+func (d *NFSStorageDriver) CreateSnapshot(snapshotName string, volConfig *storage.VolumeConfig) (
+	*storage.Snapshot, error) {
+
+	internalVolName := volConfig.InternalName
+
+	if d.Config.DebugTraceFlags["method"] {
+		fields := log.Fields{
+			"Method":       "CreateSnapshot",
+			"Type":         "NFSStorageDriver",
+			"snapshotName": snapshotName,
+			"sourceVolume": internalVolName,
+		}
+		log.WithFields(fields).Debug(">>>> CreateSnapshot")
+		defer log.WithFields(fields).Debug("<<<< CreateSnapshot")
+	}
+
+	// Make sure we got a valid name
+	if err := d.validateName(internalVolName); err != nil {
+		return nil, err
+	}
+
+	// Check if volume exists
+	volumeExists, _, err := d.API.VolumeExistsByCreationToken(internalVolName)
+	if err != nil {
+		return nil, fmt.Errorf("error checking for existing volume: %v", err)
+	}
+	if !volumeExists {
+		return nil, fmt.Errorf("volume %s does not exist", internalVolName)
+	}
+
+	// Get the source volume by creation token (efficient query) to get its ID
+	sourceVolume, err := d.API.GetVolumeByCreationToken(internalVolName)
+	if err != nil {
+		return nil, fmt.Errorf("could not find source volume: %v", err)
+	}
+
+	// Get the source volume by ID to get all details
+	sourceVolume, err = d.API.GetVolumeByID(sourceVolume.FileSystemID)
+	if err != nil {
+		return nil, fmt.Errorf("could not get source volume details: %v", err)
+	}
+
+	// Construct a snapshot request
+	snapshotCreateRequest := &api.SnapshotCreateRequest{
+		FileSystemID: sourceVolume.FileSystemID,
+		Name:         snapshotName,
+		Region:       sourceVolume.Region,
+	}
+
+	sourceSnapshot, err := d.API.CreateSnapshot(snapshotCreateRequest)
+	if err != nil {
+		return nil, fmt.Errorf("could not create source snapshot: %v", err)
+	}
+
+	// Wait for snapshot creation to complete
+	err = d.API.WaitForSnapshotState(sourceSnapshot, api.StateAvailable, []string{api.StateError})
+	if err != nil {
+		return nil, err
+	}
+
+	return &storage.Snapshot{
+		Name:    sourceSnapshot.Name,
+		Created: sourceSnapshot.Created.Format(time.RFC3339),
+	}, nil
+}
+
 // Return the list of snapshots associated with the named volume
 func (d *NFSStorageDriver) SnapshotList(name string) ([]storage.Snapshot, error) {
 

--- a/storage_drivers/eseries/eseries_iscsi.go
+++ b/storage_drivers/eseries/eseries_iscsi.go
@@ -618,6 +618,25 @@ func (d *SANStorageDriver) MapVolumeToLocalHost(volume api.VolumeEx) (api.LUNMap
 	return mapping, nil
 }
 
+// CreateSnapshot creates a snapshot for the given volume. The E-series volume plugin
+// does not support cloning or snapshots, so this method always returns an error.
+func (d *SANStorageDriver) CreateSnapshot(snapshotName string, volConfig *storage.VolumeConfig) (
+	*storage.Snapshot, error) {
+
+	if d.Config.DebugTraceFlags["method"] {
+		fields := log.Fields{
+			"Method":       "CreateSnapshot",
+			"Type":         "SANStorageDriver",
+			"snapshotName": snapshotName,
+			"sourceVolume": volConfig.InternalName,
+		}
+		log.WithFields(fields).Debug(">>>> CreateSnapshot")
+		defer log.WithFields(fields).Debug("<<<< CreateSnapshot")
+	}
+
+	return nil, errors.New("snapshotting with E-Series is not supported")
+}
+
 // SnapshotList returns the list of snapshots associated with the named volume. The E-series volume plugin does not support snapshots,
 // so this method always returns an empty array.
 func (d *SANStorageDriver) SnapshotList(name string) ([]storage.Snapshot, error) {

--- a/storage_drivers/fake/fake.go
+++ b/storage_drivers/fake/fake.go
@@ -53,7 +53,7 @@ type StorageDriver struct {
 	virtualPools  map[string]*storage.Pool
 
 	// Snapshots saves info about Snapshots created on this driver
-	Snapshots map[string][]storage.Snapshot
+	Snapshots map[string]map[string]storage.Snapshot
 }
 
 func NewFakeStorageBackend(configJSON string) (sb *storage.Backend, err error) {
@@ -83,7 +83,7 @@ func NewFakeStorageDriver(config drivers.FakeStorageDriverConfig) *StorageDriver
 		Config:           config,
 		Volumes:          make(map[string]fake.Volume),
 		DestroyedVolumes: make(map[string]bool),
-		Snapshots:        make(map[string][]storage.Snapshot),
+		Snapshots:        make(map[string]map[string]storage.Snapshot),
 	}
 	driver.populateConfigurationDefaults(&config)
 	driver.initializeStoragePools()
@@ -171,7 +171,7 @@ func (d *StorageDriver) Initialize(
 	d.Volumes = make(map[string]fake.Volume)
 	d.DestroyedVolumes = make(map[string]bool)
 	d.Config.SerialNumbers = []string{d.Config.InstanceName + "_SN"}
-	d.Snapshots = make(map[string][]storage.Snapshot)
+	d.Snapshots = make(map[string]map[string]storage.Snapshot)
 
 	s, _ := json.Marshal(d.Config)
 	log.Debugf("FakeStorageDriverConfig: %s", string(s))
@@ -585,20 +585,19 @@ func (d *StorageDriver) CreateSnapshot(snapshotName string, volConfig *storage.V
 	}
 
 	// Ensure source volume exists
-	_, ok := d.Volumes[internalVolName]
-	if !ok {
+	if _, ok := d.Volumes[internalVolName]; !ok {
 		return nil, fmt.Errorf("source volume %s not found", internalVolName)
 	}
 	// Initialize snapshots list for this volume if not present
 	if _, ok := d.Snapshots[internalVolName]; !ok {
-		d.Snapshots[internalVolName] = make([]storage.Snapshot, 0)
+		d.Snapshots[internalVolName] = make(map[string]storage.Snapshot)
 	}
 
 	snapshot := storage.Snapshot{
 		Name:    snapshotName,
-		Created: time.Now().UTC().Format("20060102T150405Z"),
+		Created: time.Now().UTC().Format(time.RFC3339),
 	}
-	d.Snapshots[internalVolName] = append(d.Snapshots[internalVolName], snapshot)
+	d.Snapshots[internalVolName][snapshotName] = snapshot
 
 	log.WithFields(log.Fields{
 		"backend":      d.Config.InstanceName,

--- a/storage_drivers/ontap/ontap_nas.go
+++ b/storage_drivers/ontap/ontap_nas.go
@@ -343,6 +343,26 @@ func (d *NASStorageDriver) Publish(name string, publishInfo *utils.VolumePublish
 	return nil
 }
 
+// CreateSnapshot creates a snapshot for the given volume
+func (d *NASStorageDriver) CreateSnapshot(snapshotName string, volConfig *storage.VolumeConfig) (
+	*storage.Snapshot, error) {
+
+	internalVolName := volConfig.InternalName
+
+	if d.Config.DebugTraceFlags["method"] {
+		fields := log.Fields{
+			"Method":       "CreateSnapshot",
+			"Type":         "NASStorageDriver",
+			"snapshotName": snapshotName,
+			"sourceVolume": internalVolName,
+		}
+		log.WithFields(fields).Debug(">>>> CreateSnapshot")
+		defer log.WithFields(fields).Debug("<<<< CreateSnapshot")
+	}
+
+	return CreateOntapSnapshot(snapshotName, internalVolName, &d.Config, d.API)
+}
+
 // Return the list of snapshots associated with the named volume
 func (d *NASStorageDriver) SnapshotList(name string) ([]storage.Snapshot, error) {
 

--- a/storage_drivers/ontap/ontap_nas_flexgroup.go
+++ b/storage_drivers/ontap/ontap_nas_flexgroup.go
@@ -320,6 +320,24 @@ func (d *NASFlexGroupStorageDriver) Publish(name string, publishInfo *utils.Volu
 	return nil
 }
 
+// CreateSnapshot creates a snapshot for the given volume
+func (d *NASFlexGroupStorageDriver) CreateSnapshot(snapshotName string, volConfig *storage.VolumeConfig) (
+	*storage.Snapshot, error) {
+
+	if d.Config.DebugTraceFlags["method"] {
+		fields := log.Fields{
+			"Method":       "CreateSnapshot",
+			"Type":         "NASFlexGroupStorageDriver",
+			"snapshotName": snapshotName,
+			"sourceVolume": volConfig.InternalName,
+		}
+		log.WithFields(fields).Debug(">>>> CreateSnapshot")
+		defer log.WithFields(fields).Debug("<<<< CreateSnapshot")
+	}
+
+	return CreateOntapSnapshot(snapshotName, volConfig.InternalName, &d.Config, d.API)
+}
+
 // Return the list of snapshots associated with the named volume
 func (d *NASFlexGroupStorageDriver) SnapshotList(name string) ([]storage.Snapshot, error) {
 

--- a/storage_drivers/ontap/ontap_nas_qtree.go
+++ b/storage_drivers/ontap/ontap_nas_qtree.go
@@ -435,6 +435,24 @@ func (d *NASQtreeStorageDriver) Publish(name string, publishInfo *utils.VolumePu
 	return nil
 }
 
+// CreateSnapshot creates a snapshot for the given volume
+func (d *NASQtreeStorageDriver) CreateSnapshot(snapshotName string, volConfig *storage.VolumeConfig) (
+	*storage.Snapshot, error) {
+
+	if d.Config.DebugTraceFlags["method"] {
+		fields := log.Fields{
+			"Method":       "CreateSnapshot",
+			"Type":         "NASQtreeStorageDriver",
+			"snapshotName": snapshotName,
+			"sourceVolume": volConfig.InternalName,
+		}
+		log.WithFields(fields).Debug(">>>> CreateSnapshot")
+		defer log.WithFields(fields).Debug("<<<< CreateSnapshot")
+	}
+
+	return nil, errors.New("snapshotting with the ONTAP NAS Economy driver is not supported")
+}
+
 // Return the list of snapshots associated with the named volume
 func (d *NASQtreeStorageDriver) SnapshotList(name string) ([]storage.Snapshot, error) {
 

--- a/storage_drivers/ontap/ontap_san.go
+++ b/storage_drivers/ontap/ontap_san.go
@@ -561,6 +561,26 @@ func (d *SANStorageDriver) getISCSITargetInfo() (iSCSINodeName string, iSCSIInte
 	return
 }
 
+// CreateSnapshot creates a snapshot for the given volume
+func (d *SANStorageDriver) CreateSnapshot(snapshotName string, volConfig *storage.VolumeConfig) (
+	*storage.Snapshot, error) {
+
+	internalVolName := volConfig.InternalName
+
+	if d.Config.DebugTraceFlags["method"] {
+		fields := log.Fields{
+			"Method":       "CreateSnapshot",
+			"Type":         "SANStorageDriver",
+			"snapshotName": snapshotName,
+			"sourceVolume": internalVolName,
+		}
+		log.WithFields(fields).Debug(">>>> CreateSnapshot")
+		defer log.WithFields(fields).Debug("<<<< CreateSnapshot")
+	}
+
+	return CreateOntapSnapshot(snapshotName, internalVolName, &d.Config, d.API)
+}
+
 // Return the list of snapshots associated with the named volume
 func (d *SANStorageDriver) SnapshotList(name string) ([]storage.Snapshot, error) {
 

--- a/storage_drivers/solidfire/solidfire_san.go
+++ b/storage_drivers/solidfire/solidfire_san.go
@@ -853,7 +853,7 @@ func (d *SANStorageDriver) CreateSnapshot(snapshotName string, volConfig *storag
 
 	snapshot, err := d.Client.CreateSnapshot(&req)
 	if err != nil {
-		return nil, fmt.Errorf("could not create source snapshot: %+v", err)
+		return nil, fmt.Errorf("could not create snapshot: %+v", err)
 	}
 
 	return &storage.Snapshot{


### PR DESCRIPTION
The idea is to support creation of snapshots by creating a `VolumeSnapshot` CR and creation of PVC/PV using the snapshot as the source. This is a part of a set of PRs to achieve the same.

### Changes
1. CreateSnapshot support for `storage_drivers`.
2. CreateVolumeSnapshot backend handler.
3. CreateVolumeSnapshot orchestrator handler.
4. Unit test to test CreateVolumeSnapshot on a fake driver.
5. Add/Get snapshot state from the persistent store and corresponding unit tests.

### Testing
1. CreateSnapshot using a fake driver
```
=== RUN   TestSnapshotVolumes
time="2019-03-03T16:34:51-08:00" level=warning msg="Trident is bootstrapping with no frontend."
time="2019-03-03T16:34:51-08:00" level=warning msg="Couldn't retrieve volume transaction logs: Unable to find key"
time="2019-03-03T16:34:51-08:00" level=info msg="Trident bootstrapped successfully."
time="2019-03-03T16:34:51-08:00" level=info msg="Newly added backend satisfies no storage classes." backend=fast-a
time="2019-03-03T16:34:51-08:00" level=info msg="Newly added backend satisfies no storage classes." backend=fast-b
time="2019-03-03T16:34:51-08:00" level=info msg="Newly added backend satisfies no storage classes." backend=slow-file
time="2019-03-03T16:34:51-08:00" level=info msg="Newly added backend satisfies no storage classes." backend=slow-block
time="2019-03-03T16:34:51-08:00" level=info msg="Storage class satisfied by 2 storage pools." storageClass=slow
time="2019-03-03T16:34:51-08:00" level=info msg="Storage class satisfied by 4 storage pools." storageClass=fast
time="2019-03-03T16:34:51-08:00" level=info msg="Created fake snapshot." backend=fast-a snapshotName=file_snapshot20190304T003451Z sourceVolume=trident-file
time="2019-03-03T16:34:51-08:00" level=info msg="Created fake snapshot." backend=slow-block snapshotName=block_snapshot20190304T003451Z sourceVolume=trident-block
--- PASS: TestSnapshotVolumes (0.00s)
```

2. Unit tests for persistent store operations
```
=== RUN   TestEtcdv2Snapshot
--- PASS: TestEtcdv2Snapshot (0.01s)

=== RUN   TestEtcdv3Snapshot
--- PASS: TestEtcdv3Snapshot (0.01s)
```
