### PR TITLE
Backend support for creating volume from snapshot

### DIFF
--- a/core/orchestrator_core_test.go
+++ b/core/orchestrator_core_test.go
@@ -2197,7 +2197,224 @@ func TestSnapshotVolumes(t *testing.T) {
 			}
 			t.Logf("\tExpected: %s\n\tGot: %s\n", string(externalSnapshotJSON), string(origSnapshotJSON))
 		}
+		orchestrator.mutex.Unlock()
+	}
 
+	cleanup(t, orchestrator)
+}
+
+func TestCreateVolumeFromSnapshot(t *testing.T) {
+	mockPools := tu.GetFakePools()
+	orchestrator := getOrchestrator()
+
+	errored := false
+	for _, c := range []struct {
+		name      string
+		protocol  config.Protocol
+		poolNames []string
+	}{
+		{
+			name:      "fast-a",
+			protocol:  config.File,
+			poolNames: []string{tu.FastSmall, tu.FastThinOnly},
+		},
+		{
+			name:      "fast-b",
+			protocol:  config.File,
+			poolNames: []string{tu.FastThinOnly, tu.FastUniqueAttr},
+		},
+		{
+			name:      "slow-file",
+			protocol:  config.File,
+			poolNames: []string{tu.SlowNoSnapshots, tu.SlowSnapshots},
+		},
+		{
+			name:      "slow-block",
+			protocol:  config.Block,
+			poolNames: []string{tu.SlowNoSnapshots, tu.SlowSnapshots, tu.MediumOverlap},
+		},
+	} {
+		pools := make(map[string]*fake.StoragePool, len(c.poolNames))
+		for _, poolName := range c.poolNames {
+			pools[poolName] = mockPools[poolName]
+		}
+		cfg, err := fakedriver.NewFakeStorageDriverConfigJSON(c.name, c.protocol,
+			pools)
+		if err != nil {
+			t.Fatalf("Unable to generate cfg JSON for %s:  %v", c.name, err)
+		}
+		_, err = orchestrator.AddBackend(cfg)
+		if err != nil {
+			t.Errorf("Unable to add backend %s:  %v", c.name, err)
+			errored = true
+		}
+		orchestrator.mutex.Lock()
+		backend, ok := orchestrator.backends[c.name]
+		if !ok {
+			t.Fatalf("Backend %s not stored in orchestrator", c.name)
+		}
+		persistentBackend, err := orchestrator.storeClient.GetBackend(
+			c.name)
+		if err != nil {
+			t.Fatalf("Unable to get backend %s from persistent store:  %v",
+				c.name, err)
+		} else if !reflect.DeepEqual(backend.ConstructPersistent(),
+			persistentBackend) {
+			t.Error("Wrong data stored for backend ", c.name)
+		}
+		orchestrator.mutex.Unlock()
+	}
+	if errored {
+		t.Fatal("Failed to add all backends; aborting remaining tests.")
+	}
+
+	// Add storage classes
+	storageClasses := []storageClassTest{
+		{
+			config: &storageclass.Config{
+				Name: "slow",
+				Attributes: map[string]sa.Request{
+					sa.IOPS:             sa.NewIntRequest(40),
+					sa.Snapshots:        sa.NewBoolRequest(true),
+					sa.ProvisioningType: sa.NewStringRequest("thin"),
+				},
+			},
+			expected: []*tu.PoolMatch{
+				{Backend: "slow-file", Pool: tu.SlowSnapshots},
+				{Backend: "slow-block", Pool: tu.SlowSnapshots},
+			},
+		},
+		{
+			config: &storageclass.Config{
+				Name: "fast",
+				Attributes: map[string]sa.Request{
+					sa.IOPS:             sa.NewIntRequest(2000),
+					sa.Snapshots:        sa.NewBoolRequest(true),
+					sa.ProvisioningType: sa.NewStringRequest("thin"),
+				},
+			},
+			expected: []*tu.PoolMatch{
+				{Backend: "fast-a", Pool: tu.FastSmall},
+				{Backend: "fast-a", Pool: tu.FastThinOnly},
+				{Backend: "fast-b", Pool: tu.FastThinOnly},
+				{Backend: "fast-b", Pool: tu.FastUniqueAttr},
+			},
+		},
+	}
+	for _, s := range storageClasses {
+		_, err := orchestrator.AddStorageClass(s.config)
+		if err != nil {
+			t.Errorf("Unable to add storage class %s:  %v", s.config.Name, err)
+			continue
+		}
+		validateStorageClass(t, orchestrator, s.config.Name, s.expected)
+	}
+
+	for _, s := range []struct {
+		name            string
+		config          *storage.VolumeConfig
+		expectedSuccess bool
+		expectedMatches []*tu.PoolMatch
+	}{
+		{
+			name:            "file",
+			config:          generateVolumeConfig("file", 1, "fast", config.File),
+			expectedSuccess: true,
+			expectedMatches: []*tu.PoolMatch{
+				{Backend: "fast-a", Pool: tu.FastSmall},
+				{Backend: "fast-a", Pool: tu.FastThinOnly},
+				{Backend: "fast-b", Pool: tu.FastThinOnly},
+				{Backend: "fast-b", Pool: tu.FastUniqueAttr},
+			},
+		},
+		{
+			name:            "block",
+			config:          generateVolumeConfig("block", 1, "slow", config.Block),
+			expectedSuccess: true,
+			expectedMatches: []*tu.PoolMatch{
+				{Backend: "slow-block", Pool: tu.SlowSnapshots},
+				{Backend: "slow-block", Pool: tu.SlowSnapshots},
+			},
+		},
+	} {
+		// Create the source volume
+		_, err := orchestrator.AddVolume(s.config)
+		if err != nil {
+			t.Errorf("%s: could not add volume: %v", s.name, err)
+			continue
+		}
+
+		orchestrator.mutex.Lock()
+		_, found := orchestrator.volumes[s.config.Name]
+		if s.expectedSuccess && !found {
+			t.Errorf("%s: did not get volume where expected.", s.name)
+			continue
+		}
+		orchestrator.mutex.Unlock()
+
+		// Now take a snapshot and ensure everything looks fine
+		snapshotName := s.config.Name + "_snapshot" + time.Now().UTC().Format(time.RFC3339)
+		snapshotResult, err := orchestrator.CreateVolumeSnapshot(snapshotName, s.config)
+		if err != nil {
+			t.Fatalf("%s: got unexpected error: %v", s.name, err)
+		}
+
+		orchestrator.mutex.Lock()
+		// Snapshot should be registered in the store
+		externalSnapshot, err := orchestrator.storeClient.GetSnapshot(snapshotName)
+		if err != nil {
+			t.Errorf("%s: unable to communicate with backing store: %v", snapshotName, err)
+		}
+		if !reflect.DeepEqual(externalSnapshot, snapshotResult) {
+			t.Errorf("%s: external snapshot %s stored in backend does not match"+
+				" created snapshot.", snapshotName, externalSnapshot.Name)
+			externalSnapshotJSON, err := json.Marshal(externalSnapshot)
+			if err != nil {
+				t.Fatal("Unable to remarshal JSON: ", err)
+			}
+			origSnapshotJSON, err := json.Marshal(snapshotResult)
+			if err != nil {
+				t.Fatal("Unable to remarshal JSON: ", err)
+			}
+			t.Logf("\tExpected: %s\n\tGot: %s\n", string(externalSnapshotJSON), string(origSnapshotJSON))
+		}
+		orchestrator.mutex.Unlock()
+
+		// Create new volume from snapshot
+		newVolConfig := s.config
+		newVolConfig.Name = s.config.Name + "_from_" + snapshotName
+		vol, err := orchestrator.CreateVolumeFromSnapshot(snapshotName, newVolConfig)
+		if err != nil {
+			t.Errorf("%s: could not create volume from snapshot: %v", s.name, err)
+			continue
+		}
+
+		orchestrator.mutex.Lock()
+		_, found = orchestrator.volumes[newVolConfig.Name]
+		if !found {
+			t.Errorf("%s: did not get volume.", s.name)
+			continue
+		}
+
+		externalVolume, err := orchestrator.storeClient.GetVolume(newVolConfig.Name)
+		if err != nil {
+			t.Errorf("%s:  unable to communicate with backing store:  %v",
+				s.name, err)
+		}
+		if !reflect.DeepEqual(externalVolume, vol) {
+			t.Errorf("%s:  external volume %s stored in backend does not match"+
+				" created volume.", s.name, externalVolume.Config.Name)
+			externalVolJSON, err := json.Marshal(externalVolume)
+			if err != nil {
+				t.Fatal("Unable to remarshal JSON:  ", err)
+			}
+			origVolJSON, err := json.Marshal(vol)
+			if err != nil {
+				t.Fatal("Unable to remarshal JSON:  ", err)
+			}
+			t.Logf("\tExpected: %s\n\tGot: %s\n", string(externalVolJSON),
+				string(origVolJSON))
+		}
 		orchestrator.mutex.Unlock()
 	}
 

--- a/storage_drivers/aws/aws_cvs.go
+++ b/storage_drivers/aws/aws_cvs.go
@@ -756,6 +756,152 @@ func (d *NFSStorageDriver) CreateClone(volConfig *storage.VolumeConfig) error {
 	return d.waitForVolumeCreate(clone, name)
 }
 
+// Create a volume with the specified options from a snapshot source
+func (d *NFSStorageDriver) CreateVolumeFromSnapshot(
+	snapshot *storage.Snapshot, volConfig *storage.VolumeConfig,
+	storagePool *storage.Pool, volAttributes map[string]sa.Request,
+) error {
+
+	name := volConfig.InternalName
+
+	if d.Config.DebugTraceFlags["method"] {
+		fields := log.Fields{
+			"Method":     "CreateFromSnapshot",
+			"Type":       "NFSStorageDriver",
+			"name":       name,
+			"snapshotID": snapshot.ID,
+		}
+		log.WithFields(fields).Debug(">>>> CreateFromSnapshot")
+		defer log.WithFields(fields).Debug("<<<< CreateFromSnapshot")
+	}
+
+	// Make sure we got a valid name
+	if err := d.validateName(name); err != nil {
+		return err
+	}
+
+	// Get the pool since most default values are pool-specific
+	if storagePool == nil {
+		return errors.New("pool not specified")
+	}
+	pool, ok := d.pools[storagePool.Name]
+	if !ok {
+		return fmt.Errorf("pool %s does not exist", storagePool.Name)
+	}
+
+	// If the volume already exists, bail out
+	volumeExists, extantVolume, err := d.API.VolumeExistsByCreationToken(name)
+	if err != nil {
+		return fmt.Errorf("error checking for existing volume: %v", err)
+	}
+	if volumeExists {
+		if extantVolume.Region != d.Config.APIRegion {
+			return fmt.Errorf("volume %s requested in region %s, but it already exists in region %s",
+				name, d.Config.APIRegion, extantVolume.Region)
+		}
+		return drivers.NewVolumeExistsError(name)
+	}
+
+	// Determine volume size in bytes
+	requestedSize, err := utils.ConvertSizeToBytes(volConfig.Size)
+	if err != nil {
+		return fmt.Errorf("could not convert volume size %s: %v", volConfig.Size, err)
+	}
+	sizeBytes, err := strconv.ParseUint(requestedSize, 10, 64)
+	if err != nil {
+		return fmt.Errorf("%v is an invalid volume size: %v", volConfig.Size, err)
+	}
+	if sizeBytes == 0 {
+		defaultSize, _ := utils.ConvertSizeToBytes(pool.InternalAttributes[Size])
+		sizeBytes, _ = strconv.ParseUint(defaultSize, 10, 64)
+	}
+	if sizeBytes < MinimumVolumeSizeBytes {
+		return fmt.Errorf("requested volume size (%d bytes) is too small; the minimum volume size is %d bytes",
+			sizeBytes, MinimumVolumeSizeBytes)
+	}
+
+	// TODO: remove this code once CVS can handle smaller volumes
+	if sizeBytes < MinimumCVSVolumeSizeBytes {
+
+		log.WithFields(log.Fields{
+			"name": name,
+			"size": sizeBytes,
+		}).Warningf("Requested size is too small. Setting volume size to the minimum allowable (100 GB).")
+
+		sizeBytes = MinimumCVSVolumeSizeBytes
+		volConfig.Size = fmt.Sprintf("%d", sizeBytes)
+	}
+
+	if _, _, err := drivers.CheckVolumeSizeLimits(sizeBytes, d.Config.CommonStorageDriverConfig); err != nil {
+		return err
+	}
+
+	// Take service level from volume config first (handles Docker case), then from pool
+	userServiceLevel := volConfig.ServiceLevel
+	if userServiceLevel == "" {
+		userServiceLevel = pool.InternalAttributes[ServiceLevel]
+	}
+	switch userServiceLevel {
+	case api.UserServiceLevel1, api.UserServiceLevel2, api.UserServiceLevel3:
+		break
+	default:
+		return fmt.Errorf("invalid service level: %s", userServiceLevel)
+	}
+	apiServiceLevel := api.APIServiceLevelFromUserServiceLevel(userServiceLevel)
+
+	log.WithFields(log.Fields{
+		"creationToken":    name,
+		"sourceSnapshot":   snapshot.Name,
+		"sourceSnapshotID": snapshot.ID,
+	}).Debug("Creating volume from snapshot.")
+
+	apiExportRule := api.ExportRule{
+		AllowedClients: pool.InternalAttributes[ExportRule],
+		Cifs:           false,
+		Nfsv3:          true,
+		Nfsv4:          true,
+		RuleIndex:      1,
+		UnixReadOnly:   false,
+		UnixReadWrite:  true,
+	}
+	exportPolicy := api.ExportPolicy{
+		Rules: []api.ExportRule{apiExportRule},
+	}
+
+	snapshotPolicy := api.SnapshotPolicy{
+		Enabled: false,
+		MonthlySchedule: api.MonthlySchedule{
+			DaysOfMonth: "1",
+		},
+		WeeklySchedule: api.WeeklySchedule{
+			Day: "Sunday",
+		},
+	}
+
+	createRequest := &api.FilesystemCreateRequest{
+		Name:           volConfig.Name,
+		Region:         d.Config.APIRegion,
+		CreationToken:  name,
+		ExportPolicy:   exportPolicy,
+		Labels:         d.getTelemetryLabels(),
+		ProtocolTypes:  []string{api.ProtocolTypeNFSv3, api.ProtocolTypeNFSv4},
+		QuotaInBytes:   int64(sizeBytes),
+		SecurityStyle:  defaultSecurityStyle,
+		ServiceLevel:   apiServiceLevel,
+		SnapshotPolicy: snapshotPolicy,
+		SnapshotID:     snapshot.ID,
+	}
+
+	// Create the volume
+	volume, err := d.API.CreateVolume(createRequest)
+	if err != nil {
+		return err
+	}
+
+	// Wait for creation to complete so that the mount targets are available
+	return d.waitForVolumeCreate(volume, name)
+}
+
 // getTelemetryLabels builds the labels that are set on each volume.
 func (d *NFSStorageDriver) getTelemetryLabels() []string {
 

--- a/storage_drivers/eseries/eseries_iscsi.go
+++ b/storage_drivers/eseries/eseries_iscsi.go
@@ -362,6 +362,26 @@ func (d *SANStorageDriver) Create(
 	return nil
 }
 
+// Create a volume with the specified options from a snapshot source
+func (d *SANStorageDriver) CreateVolumeFromSnapshot(
+	snapshot *storage.Snapshot, volConfig *storage.VolumeConfig,
+	storagePool *storage.Pool, volAttributes map[string]sa.Request,
+) error {
+
+	if d.Config.DebugTraceFlags["method"] {
+		fields := log.Fields{
+			"Method":         "CreateVolumeFromSnapshot",
+			"Type":           "SANStorageDriver",
+			"name":           volConfig.InternalName,
+			"sourceSnapshot": snapshot.Name,
+		}
+		log.WithFields(fields).Debug(">>>> CreateVolumeFromSnapshot")
+		defer log.WithFields(fields).Debug("<<<< CreateVolumeFromSnapshot")
+	}
+
+	return errors.New("creating volume from snapshot with E-Series is not supported")
+}
+
 // Destroy is called by Docker to delete a container volume.
 func (d *SANStorageDriver) Destroy(name string) error {
 

--- a/storage_drivers/fake/fake.go
+++ b/storage_drivers/fake/fake.go
@@ -534,6 +534,95 @@ func (d *StorageDriver) CreateClone(volConfig *storage.VolumeConfig) error {
 	return nil
 }
 
+func (d *StorageDriver) CreateVolumeFromSnapshot(
+	snapshot *storage.Snapshot, volConfig *storage.VolumeConfig,
+	storagePool *storage.Pool, volAttributes map[string]sa.Request,
+) error {
+
+	name := volConfig.InternalName
+	if _, ok := d.Volumes[name]; ok {
+		return drivers.NewVolumeExistsError(name)
+	}
+
+	// Check if the snapshot exists
+	if _, ok := d.Snapshots[snapshot.Name]; !ok {
+		return fmt.Errorf("source snapshot %s not found", snapshot.Name)
+	}
+
+	// Get candidate physical pools
+	physicalPools, err := d.getPoolsForCreate(volConfig, storagePool, volAttributes)
+	if err != nil {
+		return err
+	}
+
+	// Determine volume size in bytes
+	requestedSize, err := utils.ConvertSizeToBytes(volConfig.Size)
+	if err != nil {
+		return fmt.Errorf("could not convert volume size %s: %v", volConfig.Size, err)
+	}
+	sizeBytes, err := strconv.ParseUint(requestedSize, 10, 64)
+	if err != nil {
+		return fmt.Errorf("%v is an invalid volume size: %v", volConfig.Size, err)
+	}
+	if sizeBytes == 0 {
+		defaultSize, _ := utils.ConvertSizeToBytes(d.Config.Size)
+		sizeBytes, _ = strconv.ParseUint(defaultSize, 10, 64)
+	}
+	if sizeBytes < MinimumVolumeSizeBytes {
+		return fmt.Errorf("requested volume size (%d bytes) is too small; the minimum volume size is %d bytes",
+			sizeBytes, MinimumVolumeSizeBytes)
+	}
+
+	if _, _, err = drivers.CheckVolumeSizeLimits(sizeBytes, d.Config.CommonStorageDriverConfig); err != nil {
+		return err
+	}
+
+	createErrors := make([]error, 0)
+
+	for _, physicalPool := range physicalPools {
+
+		fakePoolName := physicalPool.Name
+		fakePool, ok := d.Config.Pools[physicalPool.Name]
+		if !ok {
+			errMessage := fmt.Sprintf("fake pool %s not found.", fakePoolName)
+			log.Error(errMessage)
+			createErrors = append(createErrors, errors.New(errMessage))
+			continue
+		}
+
+		if sizeBytes > fakePool.Bytes {
+			errMessage := fmt.Sprintf("requested volume is too large, requested %d bytes, "+
+				"have %d available in pool %s", sizeBytes, fakePool.Bytes, fakePoolName)
+			log.Error(errMessage)
+			createErrors = append(createErrors, errors.New(errMessage))
+			continue
+		}
+
+		d.Volumes[name] = fake.Volume{
+			Name:          name,
+			RequestedPool: storagePool.Name,
+			PhysicalPool:  fakePoolName,
+			SizeBytes:     sizeBytes,
+		}
+		d.DestroyedVolumes[name] = false
+		fakePool.Bytes -= sizeBytes
+
+		log.WithFields(log.Fields{
+			"backend":        d.Config.InstanceName,
+			"name":           name,
+			"sourceSnapshot": snapshot.Name,
+			"requestedPool":  storagePool.Name,
+			"physicalPool":   fakePoolName,
+			"sizeBytes":      sizeBytes,
+		}).Info("Created fake volume from snapshot.")
+
+		return nil
+	}
+
+	// All physical pools that were eligible ultimately failed, so don't try this backend again
+	return drivers.NewBackendIneligibleError(name, createErrors)
+}
+
 func (d *StorageDriver) Destroy(name string) error {
 
 	d.DestroyedVolumes[name] = true

--- a/storage_drivers/ontap/ontap_nas.go
+++ b/storage_drivers/ontap/ontap_nas.go
@@ -3,6 +3,7 @@
 package ontap
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -280,6 +281,26 @@ func (d *NASStorageDriver) CreateClone(volConfig *storage.VolumeConfig) error {
 
 	log.WithField("splitOnClone", split).Debug("Creating volume clone.")
 	return CreateOntapClone(name, source, snapshot, split, &d.Config, d.API)
+}
+
+// Create a volume with the specified options from a snapshot source
+func (d *NASStorageDriver) CreateVolumeFromSnapshot(
+	snapshot *storage.Snapshot, volConfig *storage.VolumeConfig,
+	storagePool *storage.Pool, volAttributes map[string]sa.Request,
+) error {
+
+	if d.Config.DebugTraceFlags["method"] {
+		fields := log.Fields{
+			"Method":         "CreateVolumeFromSnapshot",
+			"Type":           "NASStorageDriver",
+			"name":           volConfig.InternalName,
+			"sourceSnapshot": snapshot.Name,
+		}
+		log.WithFields(fields).Debug(">>>> CreateVolumeFromSnapshot")
+		defer log.WithFields(fields).Debug("<<<< CreateVolumeFromSnapshot")
+	}
+
+	return errors.New("creating volume from snapshot with ONTAP NAS storage driver is not implemented")
 }
 
 // Destroy the volume

--- a/storage_drivers/ontap/ontap_nas_flexgroup.go
+++ b/storage_drivers/ontap/ontap_nas_flexgroup.go
@@ -267,6 +267,26 @@ func (d *NASFlexGroupStorageDriver) CreateClone(volConfig *storage.VolumeConfig)
 	return errors.New("clones are not supported for FlexGroups")
 }
 
+// Create a volume with the specified options from a snapshot source
+func (d *NASFlexGroupStorageDriver) CreateVolumeFromSnapshot(
+	snapshot *storage.Snapshot, volConfig *storage.VolumeConfig,
+	storagePool *storage.Pool, volAttributes map[string]sa.Request,
+) error {
+
+	if d.Config.DebugTraceFlags["method"] {
+		fields := log.Fields{
+			"Method":         "CreateVolumeFromSnapshot",
+			"Type":           "NASFlexGroupStorageDriver",
+			"name":           volConfig.InternalName,
+			"sourceSnapshot": snapshot.Name,
+		}
+		log.WithFields(fields).Debug(">>>> CreateVolumeFromSnapshot")
+		defer log.WithFields(fields).Debug("<<<< CreateVolumeFromSnapshot")
+	}
+
+	return errors.New("creating volume from snapshot with FlexGroups is not supported")
+}
+
 // Destroy the volume
 func (d *NASFlexGroupStorageDriver) Destroy(name string) error {
 

--- a/storage_drivers/ontap/ontap_nas_qtree.go
+++ b/storage_drivers/ontap/ontap_nas_qtree.go
@@ -343,6 +343,26 @@ func (d *NASQtreeStorageDriver) CreateClone(volConfig *storage.VolumeConfig) err
 	return errors.New("cloning with the ONTAP NAS Economy driver is not supported")
 }
 
+// Create a volume with the specified options from a snapshot source
+func (d *NASQtreeStorageDriver) CreateVolumeFromSnapshot(
+	snapshot *storage.Snapshot, volConfig *storage.VolumeConfig,
+	storagePool *storage.Pool, volAttributes map[string]sa.Request,
+) error {
+
+	if d.Config.DebugTraceFlags["method"] {
+		fields := log.Fields{
+			"Method":         "CreateVolumeFromSnapshot",
+			"Type":           "NASQtreeStorageDriver",
+			"name":           volConfig.InternalName,
+			"sourceSnapshot": snapshot.Name,
+		}
+		log.WithFields(fields).Debug(">>>> CreateVolumeFromSnapshot")
+		defer log.WithFields(fields).Debug("<<<< CreateVolumeFromSnapshot")
+	}
+
+	return errors.New("creating volume from snapshot with ONTAP NAS Economy driver is not supported")
+}
+
 // Destroy the volume
 func (d *NASQtreeStorageDriver) Destroy(name string) error {
 

--- a/storage_drivers/ontap/ontap_san.go
+++ b/storage_drivers/ontap/ontap_san.go
@@ -361,6 +361,26 @@ func (d *SANStorageDriver) CreateClone(volConfig *storage.VolumeConfig) error {
 	return CreateOntapClone(name, source, snapshot, split, &d.Config, d.API)
 }
 
+// Create a volume with the specified options from a snapshot source
+func (d *SANStorageDriver) CreateVolumeFromSnapshot(
+	snapshot *storage.Snapshot, volConfig *storage.VolumeConfig,
+	storagePool *storage.Pool, volAttributes map[string]sa.Request,
+) error {
+
+	if d.Config.DebugTraceFlags["method"] {
+		fields := log.Fields{
+			"Method":         "CreateVolumeFromSnapshot",
+			"Type":           "SANStorageDriver",
+			"name":           volConfig.InternalName,
+			"sourceSnapshot": snapshot.Name,
+		}
+		log.WithFields(fields).Debug(">>>> CreateVolumeFromSnapshot")
+		defer log.WithFields(fields).Debug("<<<< CreateVolumeFromSnapshot")
+	}
+
+	return errors.New("creating volume from snapshot with ONTAP SAN storage driver is not implemented")
+}
+
 // Destroy the requested (volume,lun) storage tuple
 func (d *SANStorageDriver) Destroy(name string) error {
 

--- a/storage_drivers/solidfire/solidfire_san.go
+++ b/storage_drivers/solidfire/solidfire_san.go
@@ -728,6 +728,26 @@ func (d *SANStorageDriver) CreateClone(volConfig *storage.VolumeConfig) error {
 	return nil
 }
 
+// Create a volume with the specified options from a snapshot source
+func (d *SANStorageDriver) CreateVolumeFromSnapshot(
+	snapshot *storage.Snapshot, volConfig *storage.VolumeConfig,
+	storagePool *storage.Pool, volAttributes map[string]sa.Request,
+) error {
+
+	if d.Config.DebugTraceFlags["method"] {
+		fields := log.Fields{
+			"Method":         "CreateVolumeFromSnapshot",
+			"Type":           "SANStorageDriver",
+			"name":           volConfig.InternalName,
+			"sourceSnapshot": snapshot.Name,
+		}
+		log.WithFields(fields).Debug(">>>> CreateVolumeFromSnapshot")
+		defer log.WithFields(fields).Debug("<<<< CreateVolumeFromSnapshot")
+	}
+
+	return errors.New("creating volume from snapshot with SolidFire SAN driver is not implemented")
+}
+
 // Destroy the requested docker volume
 func (d *SANStorageDriver) Destroy(name string) error {
 


### PR DESCRIPTION
Implemented only for `fake` and `aws_cvs` drivers

Unit test for fake driver:
```
pdevaraj @ ~/go/src/github.com/netapp/trident - [test_restore] $ go test -v ./core/ -run TestCreateVolumeFromSnapshot
=== RUN   TestCreateVolumeFromSnapshot
time="2019-03-07T17:08:34-08:00" level=warning msg="Trident is bootstrapping with no frontend."
time="2019-03-07T17:08:34-08:00" level=warning msg="Couldn't retrieve volume transaction logs: Unable to find key"
time="2019-03-07T17:08:34-08:00" level=info msg="Trident bootstrapped successfully."
time="2019-03-07T17:08:34-08:00" level=info msg="Storage driver initialized." driver=fake
time="2019-03-07T17:08:34-08:00" level=info msg="Created new storage backend." backend="&{0xc0001b9600 fast-a true online map[fast-small:0xc000030c00 fast-thin-only:0xc000030c40] map[]}"
time="2019-03-07T17:08:34-08:00" level=info msg="Newly added backend satisfies no storage classes." backend=fast-a
time="2019-03-07T17:08:34-08:00" level=info msg="Storage driver initialized." driver=fake
time="2019-03-07T17:08:34-08:00" level=info msg="Created new storage backend." backend="&{0xc0002b6370 fast-b true online map[fast-unique-attr:0xc0002b2e80 fast-thin-only:0xc0002b2ec0] map[]}"
time="2019-03-07T17:08:34-08:00" level=info msg="Newly added backend satisfies no storage classes." backend=fast-b
time="2019-03-07T17:08:34-08:00" level=info msg="Storage driver initialized." driver=fake
time="2019-03-07T17:08:34-08:00" level=info msg="Created new storage backend." backend="&{0xc0002b7130 slow-file true online map[slow-no-snapshots:0xc0002e2a00 slow-snapshots:0xc0002e2a40] map[]}"
time="2019-03-07T17:08:34-08:00" level=info msg="Newly added backend satisfies no storage classes." backend=slow-file
time="2019-03-07T17:08:34-08:00" level=info msg="Storage driver initialized." driver=fake
time="2019-03-07T17:08:34-08:00" level=info msg="Created new storage backend." backend="&{0xc0002b7e40 slow-block true online map[medium-overlap:0xc00031a640 slow-no-snapshots:0xc00031a680 slow-snapshots:0xc00031a6c0] map[]}"
time="2019-03-07T17:08:34-08:00" level=info msg="Newly added backend satisfies no storage classes." backend=slow-block
time="2019-03-07T17:08:34-08:00" level=info msg="Storage class satisfied by 2 storage pools." storageClass=slow
time="2019-03-07T17:08:34-08:00" level=info msg="Storage class satisfied by 4 storage pools." storageClass=fast
time="2019-03-07T17:08:34-08:00" level=info msg="Created fake snapshot." backend=fast-a physicalPool=fast-thin-only requestedPool=fast-thin-only snapshotName="file_snapshot2019-03-08T01:08:34Z" sourceVolume=trident-file
time="2019-03-07T17:08:34-08:00" level=info msg="Created fake volume from snapshot." backend=fast-a name="trident-file_from_file_snapshot2019-03-08T01:08:34Z" physicalPool=fast-thin-only requestedPool=fast-thin-only sizeBytes=1073741824 sourceSnapshot="file_snapshot2019-03-08T01:08:34Z"
time="2019-03-07T17:08:34-08:00" level=info msg="Created fake snapshot." backend=slow-block physicalPool=slow-snapshots requestedPool=slow-snapshots snapshotName="block_snapshot2019-03-08T01:08:34Z" sourceVolume=trident-block
time="2019-03-07T17:08:34-08:00" level=info msg="Created fake volume from snapshot." backend=slow-block name="trident-block_from_block_snapshot2019-03-08T01:08:34Z" physicalPool=slow-snapshots requestedPool=slow-snapshots sizeBytes=1073741824 sourceSnapshot="block_snapshot2019-03-08T01:08:34Z"
--- PASS: TestCreateVolumeFromSnapshot (0.00s)
PASS
ok  	github.com/netapp/trident/core	0.022s
```